### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,7 +70,6 @@ while test $# -gt 0; do
       shift
       NO_APACHE=1
       NO_TOMCAT=1
-      exit 0
     ;;
     --no-apache)
       shift


### PR DESCRIPTION
remove exit in the method start only mapguide. when run container with param --only-mapguide it's not working